### PR TITLE
add KYB grant support for token generation

### DIFF
--- a/src/app-auth/services/app-auth.service.ts
+++ b/src/app-auth/services/app-auth.service.ts
@@ -33,6 +33,7 @@ export enum GRANT_TYPES {
   access_service_kyc = 'access_service_kyc',
   access_service_ssi = 'access_service_ssi',
   access_service_quest = 'access_service_quest',
+  access_service_kyb = 'access_service_kyb',
 }
 
 @Injectable()
@@ -549,6 +550,7 @@ export class AppAuthService {
   async generateAccessToken(
     appSecreatKey: string,
     expiresin = 4,
+    grantType,
   ): Promise<{ access_token; expiresIn; tokenType }> {
     Logger.log('generateAccessToken() method: starts....', 'AppAuthService');
 
@@ -608,7 +610,16 @@ export class AppAuthService {
         break;
       }
       case SERVICE_TYPES.CAVACH_API: {
-        grant_type = GRANT_TYPES.access_service_kyc;
+        if (
+          grantType &&
+          grantType !== GRANT_TYPES.access_service_kyc &&
+          grantType !== GRANT_TYPES.access_service_kyb
+        ) {
+          throw new BadRequestException([
+            'You can only choose access_service_kyc or access_service_kyb for Cavach service',
+          ]);
+        }
+        grant_type = grantType || GRANT_TYPES.access_service_kyc;
         if (userDetails.accessList && userDetails.accessList.length > 0) {
           accessList = userDetails.accessList
             .map((x) => {
@@ -711,6 +722,8 @@ export class AppAuthService {
         break;
       case GRANT_TYPES.access_service_kyc:
         break;
+      case GRANT_TYPES.access_service_kyb:
+        break;
       case GRANT_TYPES.access_service_quest:
         break;
       default: {
@@ -758,7 +771,10 @@ export class AppAuthService {
         break;
       }
       case SERVICE_TYPES.CAVACH_API: {
-        if (grantType != 'access_service_kyc') {
+        if (
+          grantType != 'access_service_kyc' &&
+          grantType != GRANT_TYPES.access_service_kyb
+        ) {
           throw new BadRequestException(
             'Invalid grant type for this service ' + appId,
           );

--- a/src/app-auth/services/app-auth.service.ts
+++ b/src/app-auth/services/app-auth.service.ts
@@ -616,7 +616,7 @@ export class AppAuthService {
           grantType !== GRANT_TYPES.access_service_kyb
         ) {
           throw new BadRequestException([
-            'You can only choose access_service_kyc or access_service_kyb for Cavach service',
+            'Choose access_service_kyc or access_service_kyb for Cavach service',
           ]);
         }
         grant_type = grantType || GRANT_TYPES.access_service_kyc;
@@ -772,7 +772,7 @@ export class AppAuthService {
       }
       case SERVICE_TYPES.CAVACH_API: {
         if (
-          grantType != 'access_service_kyc' &&
+          grantType != GRANT_TYPES.access_service_kyc &&
           grantType != GRANT_TYPES.access_service_kyb
         ) {
           throw new BadRequestException(

--- a/src/app-oauth/app-oauth.controller.ts
+++ b/src/app-oauth/app-oauth.controller.ts
@@ -77,7 +77,7 @@ export class AppOauthController {
   })
   @ApiQuery({
     name: 'grant_type',
-    description: 'Grant type for access token',
+    description: 'The type of grant used to request an access token.',
     required: false,
     enum: GRANT_TYPES,
   })

--- a/src/app-oauth/app-oauth.controller.ts
+++ b/src/app-oauth/app-oauth.controller.ts
@@ -77,7 +77,7 @@ export class AppOauthController {
   })
   @ApiQuery({
     name: 'grant_type',
-    description: 'Grant type for this token',
+    description: 'Grant type for access token',
     required: false,
     enum: GRANT_TYPES,
   })

--- a/src/app-oauth/app-oauth.controller.ts
+++ b/src/app-oauth/app-oauth.controller.ts
@@ -12,7 +12,10 @@ import {
   Req,
 } from '@nestjs/common';
 
-import { AppAuthService } from 'src/app-auth/services/app-auth.service';
+import {
+  AppAuthService,
+  GRANT_TYPES,
+} from 'src/app-auth/services/app-auth.service';
 import {
   ApiBadRequestResponse,
   ApiBearerAuth,
@@ -72,15 +75,26 @@ export class AppOauthController {
     description: 'Unauthorized',
     type: GenerateTokenError,
   })
+  @ApiQuery({
+    name: 'grant_type',
+    description: 'Grant type for this token',
+    required: false,
+    enum: GRANT_TYPES,
+  })
   @UsePipes(ValidationPipe)
   generateAccessToken(
     @Headers('X-Api-Secret-Key') apiSectretKey: string,
     @AppSecretHeader() appSecreatKey,
     @Headers('ExpiresIn') oauthexpiresin: string,
     @OauthTokenExpiryHeader() expiresin,
+    @Query('grant_type') grantType,
   ): Promise<{ access_token; expiresIn; tokenType }> {
     Logger.log('reGenerateAppSecretKey() method: starts', 'AppOAuthController');
-    return this.appAuthService.generateAccessToken(appSecreatKey, expiresin);
+    return this.appAuthService.generateAccessToken(
+      appSecreatKey,
+      expiresin,
+      grantType,
+    );
   }
 
   // grant type: [access_service], ?grant_type=access_service&serviceId=


### PR DESCRIPTION
## 🎯 Purpose
Enable support for KYB grant type (`access_service_kyb`)
---

## 📝 Changes
- Added support for the `access_service_kyb` grant type under Cavach service.  
- Previously, token generation only supported the `access_service_kyc` grant type for KYC service.  
- This change adds support for `access_service_kyb`, enabling services that require KYB access to also generate tokens.
---

## 🔄 Type
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 📝 Docs
- [ ] ♻️ Refactor
- [ ] ✅ Tests
- [ ] 🔧 Config / CI

---

## 🧪 Testing
How did you test this? (unit/integration/manual)
Manual: Verified through API calls
---

## ✅ Checklist
- [ ] Code follows Hypermine standards
- [ ] Tests/docs updated if needed
- [x] Verified locally
